### PR TITLE
Tweak: Exchange Kafka/Zookeeper with Redpanda

### DIFF
--- a/deployment/kafka/service-compose.yml
+++ b/deployment/kafka/service-compose.yml
@@ -1,33 +1,25 @@
 version: '2'
 services:
-  zookeeper:
-    container_name: zookeeper
-    image: confluentinc/cp-zookeeper:7.0.1
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
-    ports:
-      - 2181:2181
-    networks:
-      - kafkaNet
-
-  kafka:
+  kafkabroker:
+    command:
+      - redpanda
+      - start
+      - --smp
+      - '1'
+      - --reserve-memory
+      - 0M
+      - --overprovisioned
+      - --node-id
+      - '0'
+      - --kafka-addr
+      - PLAINTEXT://0.0.0.0:9092,OUTSIDE://0.0.0.0:29092
+      - --advertise-kafka-addr
+      - PLAINTEXT://kafkabroker:9092,OUTSIDE://localhost:29092
+    image: docker.vectorized.io/vectorized/redpanda:latest
     container_name: kafkabroker
-    image: confluentinc/cp-kafka:5.2.5
-    depends_on:
-      - zookeeper
-    expose:
-      - 29092
     ports:
+      - 9092:9092
       - 29092:29092
-    environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_LISTENERS: EXTERNAL_SAME_HOST://:29092,INTERNAL://:9092
-      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka:9092,EXTERNAL_SAME_HOST://localhost:29092
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL_SAME_HOST:PLAINTEXT
-      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
     networks:
       - kafkaNet
       - mainNet


### PR DESCRIPTION
Did this for my personal environment. Maybe this sounds useful for you too. 
Redpanda is a Kafka-Compatible broker rewritten in C++. Completly eliminates the need for Zookeeper, is much faster during startup (about 1 sec) and is more resource-efficient.

Take this PR as a hint, I don't explicitly recommend merging it although I don't think that it would cause any problems as it's completly compatible to Kafka. 